### PR TITLE
Ensure fact gathering as regular remote user

### DIFF
--- a/tasks/dconf.yml
+++ b/tasks/dconf.yml
@@ -9,6 +9,10 @@
     name: "{{ item }}"
   with_items: "{{ gnomeshell_dconf_reqs }}"
 
+- name: Gather facts again as non-root to ensure local user detected
+  setup:
+  become: "no"
+
 - block:
     - name: Build out list of dictionary items
       set_fact:


### PR DESCRIPTION
When gathering as root in a playbook above we can miss out on the
correct ansible local remote user variabe. Let's force a re-collection
here without use of `become`.